### PR TITLE
Fix include errors and temporary removal of broken files to get OptPlugin working

### DIFF
--- a/include/luthier/HSATooling/CodeLifter.h
+++ b/include/luthier/HSATooling/CodeLifter.h
@@ -37,7 +37,6 @@
 #include "luthier/Object/AMDGCNObjectFile.h"
 #include "luthier/Object/ObjectFileUtils.h"
 #include "luthier/Rocprofiler/ApiTableSnapshot.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include <functional>
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/CodeGen/MachineInstr.h>

--- a/include/luthier/Tooling/CodeDiscoveryPass.h
+++ b/include/luthier/Tooling/CodeDiscoveryPass.h
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 #ifndef LUTHIER_TOOLING_CODE_DISCOVERY_PASS_H
 #define LUTHIER_TOOLING_CODE_DISCOVERY_PASS_H
-#include "luthier/Tooling/MachineFunctionEntryPoint.h"
+#include "luthier/Tooling/EntryPoint.h"
 #include <llvm/IR/PassManager.h>
 
 namespace luthier {

--- a/include/luthier/Tooling/IPVectorRegLiveness.h
+++ b/include/luthier/Tooling/IPVectorRegLiveness.h
@@ -23,6 +23,7 @@
 #include "luthier/Tooling/IPPredicatedCFG.h"
 #include <llvm/ADT/DenseMap.h>
 #include <llvm/CodeGen/LivePhysRegs.h>
+#include <llvm/CodeGen/LiveRegUnits.h>
 #include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/IR/PassManager.h>
 

--- a/include/luthier/Tooling/InjectedPayloadPEIPass.h
+++ b/include/luthier/Tooling/InjectedPayloadPEIPass.h
@@ -22,10 +22,9 @@
 #ifndef LUTHIER_TOOLING_INJECTED_PAYLOAD_PEI_PASS_H
 #define LUTHIER_TOOLING_INJECTED_PAYLOAD_PEI_PASS_H
 #include "luthier/Intrinsic/IntrinsicProcessor.h"
-#include "luthier/Tooling/AMDGPURegisterLiveness.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/LRCallgraph.h"
 #include "luthier/Tooling/LegacyPassSupport.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include "luthier/Tooling/PhysicalRegAccessVirtualizationPass.h"
 #include "luthier/Tooling/PrePostAmbleEmitter.h"
 #include "luthier/Tooling/SVStorageAndLoadLocations.h"

--- a/include/luthier/Tooling/PhysicalRegAccessVirtualizationPass.h
+++ b/include/luthier/Tooling/PhysicalRegAccessVirtualizationPass.h
@@ -23,10 +23,9 @@
 #ifndef LUTHIER_TOOLING_PHYSICAL_REG_ACCESS_VIRTUALIZATION_PASS_H
 #define LUTHIER_TOOLING_PHYSICAL_REG_ACCESS_VIRTUALIZATION_PASS_H
 #include "luthier/Intrinsic/IntrinsicProcessor.h"
-#include "luthier/Tooling/AMDGPURegisterLiveness.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/LRCallgraph.h"
 #include "luthier/Tooling/LegacyPassSupport.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include "luthier/Tooling/SVStorageAndLoadLocations.h"
 #include <llvm/CodeGen/MachineFunctionPass.h>
 #include <llvm/IR/PassManager.h>

--- a/include/luthier/Tooling/PrePostAmbleEmitter.h
+++ b/include/luthier/Tooling/PrePostAmbleEmitter.h
@@ -27,7 +27,6 @@
 #include "luthier/HSA/LoadedCodeObjectDeviceFunction.h"
 #include "luthier/HSA/LoadedCodeObjectKernel.h"
 #include "luthier/Intrinsic/IntrinsicProcessor.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include <llvm/ADT/DenseSet.h>
 #include <llvm/CodeGen/MachineFunctionPass.h>
 #include <llvm/Support/Error.h>
@@ -35,8 +34,6 @@
 namespace luthier {
 
 class SVStorageAndLoadLocations;
-
-class LiftedRepresentation;
 
 /// \brief a struct which aggregates information about the preamble code
 /// required to be emitted for each function inside a \c LiftedRepresentation

--- a/include/luthier/Tooling/SVStorageAndLoadLocations.h
+++ b/include/luthier/Tooling/SVStorageAndLoadLocations.h
@@ -26,11 +26,10 @@
 #include "luthier/HSA/LoadedCodeObjectDeviceFunction.h"
 #include "luthier/HSA/LoadedCodeObjectKernel.h"
 #include "luthier/Tooling/IModuleIRGeneratorPass.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include "luthier/Tooling/MMISlotIndexesAnalysis.h"
 #include "luthier/Tooling/PrePostAmbleEmitter.h"
 #include "luthier/Tooling/StateValueArrayStorage.h"
-#include "luthier/Tooling/VectorRegLiveness.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include <llvm/CodeGen/SlotIndexes.h>
 #include <llvm/IR/PassManager.h>
 

--- a/include/luthier/Tooling/StateValueArrayStorage.h
+++ b/include/luthier/Tooling/StateValueArrayStorage.h
@@ -22,8 +22,7 @@
 #include "luthier/HSA/LoadedCodeObject.h"
 #include "luthier/HSA/LoadedCodeObjectDeviceFunction.h"
 #include "luthier/HSA/LoadedCodeObjectKernel.h"
-#include "luthier/Tooling/AMDGPURegisterLiveness.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/PrePostAmbleEmitter.h"
 #include <llvm/CodeGen/SlotIndexes.h>
 

--- a/include/luthier/Tooling/WrapperAnalysisPasses.h
+++ b/include/luthier/Tooling/WrapperAnalysisPasses.h
@@ -22,7 +22,6 @@
 #define LUTHIER_TOOLING_WRAPPER_ANALYSIS_PASSES_H
 #include "luthier/Intrinsic/IntrinsicProcessor.h"
 #include "luthier/Tooling/LegacyPassSupport.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include <llvm/Analysis/CGSCCPassManager.h>
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/IR/PassManager.h>

--- a/include/luthier/luthier.h
+++ b/include/luthier/luthier.h
@@ -32,7 +32,6 @@
 #include "luthier/HSA/LoadedCodeObjectKernel.h"
 #include "luthier/HSA/LoadedCodeObjectSymbol.h"
 #include "luthier/Intrinsic/Intrinsics.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 
 namespace luthier {
 

--- a/src/lib/HSATooling/CMakeLists.txt
+++ b/src/lib/HSATooling/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_library(LuthierHSATooling OBJECT
-        CodeGenerator.cpp
-        CodeLifter.cpp
-        Context.cpp
+        #CodeGenerator.cpp
+        #CodeLifter.cpp
+        #Context.cpp
         HsaMemoryAllocationAccessor.cpp
-        InstrumentationModule.cpp
-        InstrumentationTask.cpp
+        #InstrumentationModule.cpp
+        #InstrumentationTask.cpp
         TargetManager.cpp
-        ToolExecutableLoader.cpp
+        #ToolExecutableLoader.cpp
 )
 
 target_compile_definitions(LuthierHSATooling PRIVATE AMD_INTERNAL_BUILD ${LLVM_DEFINITIONS})

--- a/src/lib/HSATooling/CodeGenerator.cpp
+++ b/src/lib/HSATooling/CodeGenerator.cpp
@@ -31,7 +31,7 @@
 #include "luthier/Tooling/PrePostAmbleEmitter.h"
 #include "luthier/Tooling/RunIRPassesOnIModulePass.h"
 #include "luthier/Tooling/RunMIRPassesOnIModulePass.h"
-#include "luthier/Tooling/VectorRegLiveness.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/WrapperAnalysisPasses.h"
 #include <AMDGPUResourceUsageAnalysis.h>
 #include <AMDGPUTargetMachine.h>

--- a/src/lib/Intrinsic/CMakeLists.txt
+++ b/src/lib/Intrinsic/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(LuthierIntrinsic OBJECT
         ReadReg.cpp
         WriteReg.cpp
         WriteExec.cpp
-        IntrinsicProcessor.cpp
         ImplicitArgPtr.cpp
         SAtomicAdd.cpp
 )

--- a/src/lib/Plugins/OptPlugin/CMakeLists.txt
+++ b/src/lib/Plugins/OptPlugin/CMakeLists.txt
@@ -4,7 +4,7 @@ add_llvm_pass_plugin(LuthierOptPlugin
         $<TARGET_OBJECTS:LuthierCommon>
         $<TARGET_OBJECTS:LuthierObject>
         $<TARGET_OBJECTS:LuthierLLVM>
-        $<TARGET_OBJECTS:LuthierIntrinsic>
+        #$<TARGET_OBJECTS:LuthierIntrinsic>
 )
 
 target_compile_definitions(LuthierOptPlugin PRIVATE AMD_INTERNAL_BUILD ${LLVM_DEFINITIONS})

--- a/src/lib/Plugins/OptPlugin/OptPlugin.cpp
+++ b/src/lib/Plugins/OptPlugin/OptPlugin.cpp
@@ -24,7 +24,7 @@
 #include "luthier/Tooling/InitialEntryPointAnalysis.h"
 #include "luthier/Tooling/InstructionTracesAnalysis.h"
 // #include "luthier/Tooling/InstrumentationPMDriver.h"
-#include "luthier/Tooling/IntrinsicMIRLoweringPass.h"
+// #include "luthier/Tooling/IntrinsicMIRLoweringPass.h"
 // #include "luthier/Tooling/LRCallgraph.h"
 // #include "luthier/Tooling/MMISlotIndexesAnalysis.h"
 #include "luthier/Tooling/EntryPoint.h"
@@ -210,8 +210,8 @@ llvmGetPassPluginInfo() {
         [](llvm::MachineFunctionAnalysisManager &MFAM) {
           MFAM.registerPass(
               []() { return luthier::InstructionTracesAnalysis(); });
-          MFAM.registerPass(
-              []() { return luthier::MachineFunctionEntryPoint(); });
+          // MFAM.registerPass(
+          //     []() { return luthier::MachineFunctionEntryPoint(); });
         });
 
     PB.registerPipelineParsingCallback(

--- a/src/lib/Plugins/OptPlugin/OptPlugin.cpp
+++ b/src/lib/Plugins/OptPlugin/OptPlugin.cpp
@@ -27,7 +27,7 @@
 #include "luthier/Tooling/IntrinsicMIRLoweringPass.h"
 // #include "luthier/Tooling/LRCallgraph.h"
 // #include "luthier/Tooling/MMISlotIndexesAnalysis.h"
-#include "luthier/Tooling/MachineFunctionEntryPoint.h"
+#include "luthier/Tooling/EntryPoint.h"
 #include "luthier/Tooling/MemoryAllocationAccessor.h"
 #include "luthier/Tooling/MetadataParserAnalysis.h"
 #include "luthier/Tooling/MockAMDGPULoader.h"

--- a/src/lib/ToolingCommon/CMakeLists.txt
+++ b/src/lib/ToolingCommon/CMakeLists.txt
@@ -15,11 +15,9 @@ add_library(LuthierToolingCommon OBJECT
         TargetMachineInstrMDNode.cpp
         CodeDiscoveryPass.cpp
         MachineFunctionEntryPoint.cpp
-        MachineToTraceInstrAnalysis.cpp
         InstructionTracesAnalysis.cpp
         MemoryAllocationAccessor.cpp
         InstructionModel.cpp
-        LiftedRepresentation.cpp
         #        PhysicalRegAccessVirtualizationPass.cpp
         #        SVStorageAndLoadLocations.cpp
         #        LRCallGraph.cpp

--- a/src/lib/ToolingCommon/CodeDiscoveryPass.cpp
+++ b/src/lib/ToolingCommon/CodeDiscoveryPass.cpp
@@ -7,7 +7,7 @@
 // #include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/InitialEntryPointAnalysis.h"
 #include "luthier/Tooling/InstructionTracesAnalysis.h"
-#include "luthier/Tooling/MachineFunctionEntryPoint.h"
+#include "luthier/Tooling/EntryPoint.h"
 #include "luthier/Tooling/MemoryAllocationAccessor.h"
 #include "luthier/Tooling/MetadataParserAnalysis.h"
 #include "luthier/Tooling/PseudoOpcodeAnRegMapper.h"

--- a/src/lib/ToolingCommon/IPVectorRegLiveness.cpp
+++ b/src/lib/ToolingCommon/IPVectorRegLiveness.cpp
@@ -18,8 +18,10 @@
 //===----------------------------------------------------------------------===//
 #include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/IPPredicatedCFG.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include <llvm/Support/TimeProfiler.h>
+#include <llvm/CodeGen/TargetSubtargetInfo.h>
+#include <llvm/CodeGen/MachineRegisterInfo.h>
+
 
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "luthier-lr-register-liveness"

--- a/src/lib/ToolingCommon/IndirectBranchResolverAnalysis.cpp
+++ b/src/lib/ToolingCommon/IndirectBranchResolverAnalysis.cpp
@@ -20,7 +20,7 @@
 #include "luthier/Tooling/IPPredicatedCFG.h"
 #include "luthier/Tooling/IPReachingDefAnalysis.h"
 #include "luthier/Tooling/IPVectorRegLiveness.h"
-#include "luthier/Tooling/MachineFunctionEntryPoint.h"
+#include "luthier/Tooling/EntryPoint.h"
 #include <llvm/Support/GenericDomTree.h>
 
 namespace luthier {

--- a/src/lib/ToolingCommon/InjectedPayloadPEIPass.cpp
+++ b/src/lib/ToolingCommon/InjectedPayloadPEIPass.cpp
@@ -21,7 +21,6 @@
 #include "luthier/Tooling/InjectedPayloadPEIPass.h"
 #include "luthier/LLVM/streams.h"
 #include "luthier/Tooling/IntrinsicMIRLoweringPass.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include "luthier/Tooling/PhysRegsNotInLiveInsAnalysis.h"
 #include "luthier/Tooling/SVStorageAndLoadLocations.h"
 #include "luthier/Tooling/StateValueArraySpecs.h"

--- a/src/lib/ToolingCommon/InstructionTracesAnalysis.cpp
+++ b/src/lib/ToolingCommon/InstructionTracesAnalysis.cpp
@@ -18,7 +18,7 @@
 //===----------------------------------------------------------------------===//
 #include "luthier/Tooling/InstructionTracesAnalysis.h"
 #include "luthier/Common/GenericLuthierError.h"
-#include "luthier/Tooling/MachineFunctionEntryPoint.h"
+#include "luthier/Tooling/EntryPoint.h"
 #include "luthier/Tooling/MemoryAllocationAccessor.h"
 #include "luthier/Tooling/PseudoOpcodeAnRegMapper.h"
 #include <AMDGPUTargetMachine.h>

--- a/src/lib/ToolingCommon/LRCallGraph.cpp
+++ b/src/lib/ToolingCommon/LRCallGraph.cpp
@@ -18,7 +18,6 @@
 /// This file implements the \c LRCallgraph class.
 //===----------------------------------------------------------------------===//
 #include "luthier/Tooling/LRCallgraph.h"
-#include "luthier/Tooling/LiftedRepresentation.h"
 #include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
 

--- a/src/lib/ToolingCommon/MachineFunctionEntryPoint.cpp
+++ b/src/lib/ToolingCommon/MachineFunctionEntryPoint.cpp
@@ -16,7 +16,7 @@
 /// \file
 /// Implements the \c MachineFunctionEntryPoints analysis.
 //===----------------------------------------------------------------------===//
-#include "luthier/Tooling/MachineFunctionEntryPoint.h"
+#include "luthier/Tooling/EntryPoint.h"
 
 namespace luthier {
 

--- a/src/lib/ToolingCommon/MachineFunctionEntryPoint.cpp
+++ b/src/lib/ToolingCommon/MachineFunctionEntryPoint.cpp
@@ -20,6 +20,6 @@
 
 namespace luthier {
 
-llvm::AnalysisKey MachineFunctionEntryPoint::Key;
+//llvm::AnalysisKey MachineFunctionEntryPoint::Key;
 
 }

--- a/src/lib/ToolingCommon/PhysRegsNotInLiveInsAnalysis.cpp
+++ b/src/lib/ToolingCommon/PhysRegsNotInLiveInsAnalysis.cpp
@@ -20,7 +20,7 @@
 /// live-in set.
 //===----------------------------------------------------------------------===//
 #include "luthier/Tooling/PhysRegsNotInLiveInsAnalysis.h"
-#include "luthier/Tooling/VectorRegLiveness.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/IModuleIRGeneratorPass.h"
 #include "luthier/Tooling/WrapperAnalysisPasses.h"
 

--- a/src/lib/ToolingCommon/SVStorageAndLoadLocations.cpp
+++ b/src/lib/ToolingCommon/SVStorageAndLoadLocations.cpp
@@ -24,7 +24,7 @@
 #include "luthier/Tooling/MMISlotIndexesAnalysis.h"
 #include "luthier/Tooling/PhysRegsNotInLiveInsAnalysis.h"
 #include "luthier/Tooling/StateValueArrayStorage.h"
-#include "luthier/Tooling/VectorRegLiveness.h"
+#include "luthier/Tooling/IPVectorRegLiveness.h"
 #include "luthier/Tooling/WrapperAnalysisPasses.h"
 #include <GCNSubtarget.h>
 #include <llvm/CodeGen/TargetRegisterInfo.h>


### PR DESCRIPTION
This PR adresses the fact that OptPlugin cannot be compiled. This is blocking PR #75 since I cannot test without it working. This does not fix all errors, but adresses the easier ones to resolve. Changes include the removal of the include LifterRepressentation which ahs been deleted, AMDGPURegisterLiveness which was replaced by IPVectorRegLiveness and some other stuff, while also temporarly removing the dependency of OptPlugin with LuthierIntrinsics, as all of the intrinsics will not compile. 