### PR TITLE
Added Support for Loading Luthier Instrumentation Modules from HIP FAT Binaries

### DIFF
--- a/include/luthier/HSATooling/ToolExecutableLoader.h
+++ b/include/luthier/HSATooling/ToolExecutableLoader.h
@@ -190,6 +190,18 @@ private:
   std::unordered_map<hsa_executable_symbol_t,
                      llvm::StringMap<hsa_executable_symbol_t>>
       OriginalToInstrumentedKernelsMap{};
+
+  /// FIXME: Should this be SmallDenseMap for optimization? 
+  /// \brief Only load the most specific compatible Code Object
+  /// Examle: amdgcn-amd-amdhsa--gfx908 is more specific 
+  /// than amdgcn-amd-amdhsa--gfx90a which is the general architecture,
+  /// and will thus be prefered  
+  llvm::DenseMap<hsa_agent_t, hsa_executable_t> AgentLoadedExecutables;
+
+  /// \brief A mapping of agent to llvm Bitcode appropriate for the Agent
+  llvm::DenseMap<hsa_agent_t, llvm::StringRef> AgentExecutableBitcode;
+
+  llvm::SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 4> ManagedFatBinBuffers;
 };
 }; // namespace luthier
 

--- a/include/luthier/HSATooling/ToolExecutableLoader.h
+++ b/include/luthier/HSATooling/ToolExecutableLoader.h
@@ -153,6 +153,8 @@ public:
     return SIM;
   }
 
+  llvm::Error RegisterFatBinary(const void* RawFatBinWrapper);
+
   ~ToolExecutableLoader() override;
 
 private:

--- a/src/lib/HSATooling/ToolExecutableLoader.cpp
+++ b/src/lib/HSATooling/ToolExecutableLoader.cpp
@@ -25,6 +25,7 @@
 #include "luthier/HSATooling/LoadedCodeObjectCache.h"
 #include "luthier/HSATooling/TargetManager.h"
 #include "luthier/Object/AMDGCNObjectFile.h"
+#include "luthier/Object/ObjectFileUtils.h"
 #include "llvm/Object/OffloadBundle.h"
 
 #include <llvm/ADT/SmallVector.h>
@@ -476,11 +477,11 @@ llvm::Error ToolExecutableLoader::RegisterFatBinary(const void* RawFatBinWrapper
 		return FatBinBundleOrErr.takeError();
 	std::unique_ptr<llvm::object::OffloadBundleFatBin> FatBinBundle = std::move(*FatBinBundleOrErr); 
 	llvm::SmallVector<llvm::object::OffloadBundleEntry> FatBinEntries = FatBinBundle->GetEntries();
-	llvm::SmallVector<luthier::hsa::hsa_agent_t, 4> AvailableAgents;
+	llvm::SmallVector<hsa_agent_t, 4> AvailableAgents;
 	/// FIXME: Change to hsa_agent_t-> vector<std::string(ISA name)
-	llvm::DenseMap<luthier::hsa::hsa_agent_t, llvm::SmallVector<luthier::hsa::hsa_isa_t, 4>> AgentSupportedISA;
+	llvm::DenseMap<hsa_agent_t, llvm::SmallVector<hsa_isa_t, 4>> AgentSupportedISA;
 	/// Probably move this in TEL members
-	llvm::DenseMap<luthier::hsa::hsa_agent_t, llvm::SmallVector<luthier::hsa::hsa_executable_t, 4>> AgentLoadedExecutables;
+	llvm::DenseMap<hsa_agent_t, llvm::SmallVector<hsa_executable_t, 4>> AgentLoadedExecutables;
 	auto Err = luthier::hsa::getGpuAgents(CoreApiSnapshot.getTable(), AvailableAgents);
 	if(Err != llvm::Error::success())
 		return Err;
@@ -491,10 +492,36 @@ llvm::Error ToolExecutableLoader::RegisterFatBinary(const void* RawFatBinWrapper
 			return Err;
 	}
 	for(llvm::object::OffloadBundleEntry BundleEntry : FatBinEntries){
-		void* CO = FatBinData + BundleEntry.Offset;
+		void* COData = FatBinData + BundleEntry.Offset;
 		size_t COSize = BundleEntry.Size;
+		std::unique_ptr<llvm::MemoryBuffer> COBufferRaw = llvm::MemoryBuffer::getMemBuffer(
+			llvm::StringRef(COData, COSize),
+			"CO object",
+			/*RequiresNullTerminator=*/false);
+		llvm::MemoryBufferRef COBufferRef = COBufferRaw->getMemBufferRef();
+		auto COErr = luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
+		if(!COErr){
+			return COErr.takeError();
+		}
+		std::unique_ptr<luthier::object::AMDGCNObjectFile> CO = std::move(*COErr);
+		auto TargetTupleOrErr = luthier::object::getObjectFileTargetTuple(*CO);
+		if(!TargetTupleOrErr){
+			TargetTupleOrErr.takeError();
+		}
+		std::tuple<llvm::Triple, llvm::StringRef, llvm::SubtargetFeatures> TargetTuple = std::move(*TupleOrErr);
+
+		// Pluck individual items out using their index (0, 1, 2)
+		llvm::Triple            Triple   = std::get<0>(TargetTuple);
+		llvm::StringRef         CpuName  = std::get<1>(TargetTuple);
+		llvm::SubtargetFeatures Features = std::get<2>(TargetTuple);
+
+		auto ISAOrErr = luthier::hsa::isaFromLLVM(CoreApiSnapshot.getTable(), Triple, CpuName, Features);
+		if(!ISAOrErr){
+			ISAOrErr.takeError();
+		}
+		hsa_isa_t CodeObjectISA = std::move(*ISAOrErr);
 		for(auto Agent : AvailableAgents){
-			// Loop through AGENT IS
+			// Loop through AGENT ISA and compare handles
 		}
 	}
 }

--- a/src/lib/HSATooling/ToolExecutableLoader.cpp
+++ b/src/lib/HSATooling/ToolExecutableLoader.cpp
@@ -25,6 +25,7 @@
 #include "luthier/HSATooling/LoadedCodeObjectCache.h"
 #include "luthier/HSATooling/TargetManager.h"
 #include "luthier/Object/AMDGCNObjectFile.h"
+#include "llvm/Object/OffloadBundle.h"
 
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/Analysis/ValueTracking.h>
@@ -33,8 +34,99 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
+#include <cstring>
+
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "luthier-tool-executable-manager"
+
+namespace {
+
+// In uncompressed mode
+constexpr char kOffloadBundleUncompressedMagicStr[] = "__CLANG_OFFLOAD_BUNDLE__";
+static constexpr size_t kOffloadBundleUncompressedMagicStrSize =
+		sizeof(kOffloadBundleUncompressedMagicStr);
+
+// In compressed mode
+constexpr char kOffloadBundleCompressedMagicStr[] = "CCOB";
+static constexpr size_t kOffloadBundleCompressedMagicStrSize =
+		sizeof(kOffloadBundleCompressedMagicStr);
+
+constexpr uint32_t HipFatMAGIC2 = 0x48495046;
+/// Use the same structure as the hipFatBinary
+
+struct HipFatBinary{
+	uint32_t magic;
+	uint32_t version;
+	void* binary;
+	void* dummy1;
+};
+
+bool IsCodeObjectUncompressed(const void* Image) {
+  return std::memcmp(Image,
+                     reinterpret_cast<const void*>(symbols::kOffloadBundleUncompressedMagicStr),
+                     sizeof(symbols::kOffloadBundleUncompressedMagicStr) - 1) == 0;
+}
+
+bool IsCodeObjectCompressed(const void* Image) {
+  return std::memcmp(Image,
+                     reinterpret_cast<const void*>(symbols::kOffloadBundleCompressedMagicStr),
+                     sizeof(symbols::kOffloadBundleCompressedMagicStr) - 1) == 0;
+}
+
+uint64_t CalculateFatBinarySize(const void* Image, bool& IsCompressed){
+	const char* HeaderPtr = static_cast<const char*>(Image);
+	if(IsCodeObjectCompressed(Image)){
+		IsCompressed = true;
+		/// Skip the magic
+		HeaderPtr += 4;
+		uint16_t Version = *reinterpret_cast<const uint16_t*>(HeaderPtr);
+		/// Version num consumed and compression method
+		HeaderPtr += 4;
+		if(Version == 2){
+			uint32_t TotalSize = *reinterpret_cast<const uint32_t*>(HeaderPtr);
+			return TotalSize;
+		}
+		else if(Version == 3)	
+			return *reinterpret_cast<const uint64_t*>(HeaderPtr);
+		else
+			return 0;
+	}
+	/// TODO: Add FatBin offsets here for reference and above
+	else if (IsCodeObjectUncompressed(Image)) {
+    // 1. Skip Magic String (24 bytes)
+    HeaderPtr += 24; 
+    
+    // 2. Read Number of Entries
+    uint64_t NumOfEntries = *reinterpret_cast<const uint64_t*>(HeaderPtr);
+    if (NumOfEntries == 0) return 32; // Magic(24) + Count(8)
+    HeaderPtr += 8;
+
+    // We track the furthest byte reached in the file to determine TotalSize
+    uint64_t FileTail = 0;
+
+    // 3. Walk the Metadata Table
+    for (uint64_t i = 0; i < NumOfEntries; ++i) {
+        // Read fields exactly as laid out in the "Bundled Code Object Layout"
+        uint64_t ObjOffset = *reinterpret_cast<const uint64_t*>(HeaderPtr);
+        uint64_t ObjSize   = *reinterpret_cast<const uint64_t*>(HeaderPtr + 8);
+        uint64_t IDLength  = *reinterpret_cast<const uint64_t*>(HeaderPtr + 16);
+
+        // Track the end of the actual binary data blobs
+        uint64_t EndOfCurrentBlob = ObjOffset + ObjSize;
+        if (EndOfCurrentBlob > FileTail) {
+            FileTail = EndOfCurrentBlob;
+        }
+        // Move HeaderPtr to the start of the next entry:
+        // Offset(8) + Size(8) + IDLength(8) + The ID String itself
+        HeaderPtr += (24 + IDLength);
+    }
+    // The total size is the end of the last code object found
+    return FileTail;
+	}	
+	// Was not expecting an ELF here
+	return 0;
+}
+} // namespace
 
 namespace luthier {
 
@@ -333,6 +425,78 @@ bool ToolExecutableLoader::isKernelInstrumented(
              *Kernel.getExecutableSymbol()) &&
          OriginalToInstrumentedKernelsMap.find(*Kernel.getExecutableSymbol())
              ->second.contains(Preset);
+}
+
+
+
+llvm::Error ToolExecutableLoader::RegisterFatBinary(const void* RawFatBinWrapper){
+	const HipFatBinary* FatBinWrapper = static_cast<HipFatBinary*>(RawFatBinWrapper);
+	LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
+		FatBinWrapper->version == 1,
+		llvm::formatv("Cannot Register fat binary. Invalid version: {0}",
+									FatBinWrapper->version)));
+	LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
+		FatBinWrapper->magic == HipFatMAGIC2,
+		llvm::formatv("Fat binary wrapper has {0} magic number instead of {1}",
+									FatBinWrapper->magic, HipFatMAGIC2)));
+	void* Binary = FatBinWrapper->binary;
+	bool IsCompressed = false;
+	uint64_t BinarySize = CalculateBinarySize(Binary, IsCompressed);
+	LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
+		BinarySize == 0,
+		llvm::formatv("Fat binary is malformed or incorrect")));
+	if(IsCompressed && BinarySize == 32) return llvm::Error::success(); // No binaries to be processed???
+
+	const char* FatBinData = static_cast<const char*>(Binary);
+	std::unique_ptr<llvm::MemoryBuffer> RawBuffer = llvm::MemoryBuffer::getMemBuffer(
+			llvm::StringRef(FatBinData, BinarySize),
+			"Fat Binary Buffer",
+			/*RequiresNullTerminator=*/false
+	);
+
+	std::unique_ptr<llvm::MemoryBuffer> FinalDecompressedBuffer;
+	if (IsCompressed) {
+			auto DecompressedOrErr = llvm::object::CompressedOffloadBundle::decompress(*RawBuffer);
+			/// TODO: Update this
+			if (!DecompressedOrErr) {		
+					return DecompressedOrErr.takeError();
+			}
+			
+			// Ownership of the newly allocated, decompressed heap memory is moved here
+			FinalDecompressedBuffer = std::move(*DecompressedOrErr);
+	} else {
+			// If it's not compressed, just pass the raw wrapper right through.
+			// Zero allocations, zero copies.
+			FinalDecompressedBuffer = std::move(RawBuffer);
+	}
+
+	llvm::MemoryBufferRef FatBinRef = FinalDecompressedBuffer->getMemBufferRef();
+	auto FatBinBundleOrErr = llvm::object::OffloadBundleFatBin::create(FatBinRef, 0, "hip-fat-binary");
+	if(!FatBinBundleOrErr)
+		return FatBinBundleOrErr.takeError();
+	std::unique_ptr<llvm::object::OffloadBundleFatBin> FatBinBundle = std::move(*FatBinBundleOrErr); 
+	llvm::SmallVector<llvm::object::OffloadBundleEntry> FatBinEntries = FatBinBundle->GetEntries();
+	llvm::SmallVector<luthier::hsa::hsa_agent_t, 4> AvailableAgents;
+	/// FIXME: Change to hsa_agent_t-> vector<std::string(ISA name)
+	llvm::DenseMap<luthier::hsa::hsa_agent_t, llvm::SmallVector<luthier::hsa::hsa_isa_t, 4>> AgentSupportedISA;
+	/// Probably move this in TEL members
+	llvm::DenseMap<luthier::hsa::hsa_agent_t, llvm::SmallVector<luthier::hsa::hsa_executable_t, 4>> AgentLoadedExecutables;
+	auto Err = luthier::hsa::getGpuAgents(CoreApiSnapshot.getTable(), AvailableAgents);
+	if(Err != llvm::Error::success())
+		return Err;
+	
+	for(auto Agent : AvailableAgents){
+		auto Err = luthier::hsa::agentGetSupportedISAs(CoreApiSnapshot.getTable(), Agent, AgentSupportedISA[Agent]);
+		if(Err != llvm::Error::success())
+			return Err;
+	}
+	for(llvm::object::OffloadBundleEntry BundleEntry : FatBinEntries){
+		void* CO = FatBinData + BundleEntry.Offset;
+		size_t COSize = BundleEntry.Size;
+		for(auto Agent : AvailableAgents){
+			// Loop through AGENT IS
+		}
+	}
 }
 
 ToolExecutableLoader::~ToolExecutableLoader() {

--- a/src/lib/HSATooling/ToolExecutableLoader.cpp
+++ b/src/lib/HSATooling/ToolExecutableLoader.cpp
@@ -615,11 +615,12 @@ ToolExecutableLoader::RegisterFatBinary(const void *RawFatBinWrapper) {
 				/// If try_emplace fails this means an entry for this agent exists 
 				/// and we need to determine the best CO
 				bool IsGeneric = object::isGenericAMDGPUMach(GetMach(*CO));
-				// auto [it, Inserted] = AgentCompatibleCO.try_emplace(Agent, BundleEntry, AgentISA, IsGeneric);
 				auto it = AgentCompatibleCO.find(Agent);
+
 				if (it == AgentCompatibleCO.end()) {
           auto NewCOErr = luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
           LUTHIER_RETURN_ON_ERROR(NewCOErr.takeError());
+			
           AgentCompatibleCO[Agent] = { BundleEntry, AgentISA, IsGeneric, std::move(*NewCOErr) };
         }
 				else {
@@ -630,6 +631,7 @@ ToolExecutableLoader::RegisterFatBinary(const void *RawFatBinWrapper) {
           if (MostCompatible == AgentISA) {
             auto NewCOErr = luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
             LUTHIER_RETURN_ON_ERROR(NewCOErr.takeError());
+						
             it->second = { BundleEntry, AgentISA, IsGeneric, std::move(*NewCOErr) };
           }
 				}

--- a/src/lib/HSATooling/ToolExecutableLoader.cpp
+++ b/src/lib/HSATooling/ToolExecutableLoader.cpp
@@ -28,7 +28,6 @@
 #include "luthier/Object/ObjectFileUtils.h"
 #include "llvm/Object/OffloadBundle.h"
 
-#include <llvm/ADT/SmallVector.h>
 #include <llvm/Analysis/ValueTracking.h>
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
@@ -43,63 +42,66 @@
 namespace {
 
 // In uncompressed mode
-constexpr char kOffloadBundleUncompressedMagicStr[] = "__CLANG_OFFLOAD_BUNDLE__";
+constexpr char kOffloadBundleUncompressedMagicStr[] =
+    "__CLANG_OFFLOAD_BUNDLE__";
 static constexpr size_t kOffloadBundleUncompressedMagicStrSize =
-		sizeof(kOffloadBundleUncompressedMagicStr);
+    sizeof(kOffloadBundleUncompressedMagicStr);
 
 // In compressed mode
 constexpr char kOffloadBundleCompressedMagicStr[] = "CCOB";
 static constexpr size_t kOffloadBundleCompressedMagicStrSize =
-		sizeof(kOffloadBundleCompressedMagicStr);
+    sizeof(kOffloadBundleCompressedMagicStr);
 
 constexpr uint32_t HipFatMAGIC2 = 0x48495046;
 /// Use the same structure as the hipFatBinary
 
-struct HipFatBinary{
-	uint32_t magic;
-	uint32_t version;
-	void* binary;
-	void* dummy1;
+struct HipFatBinary {
+  uint32_t magic;
+  uint32_t version;
+  void *binary;
+  void *dummy1;
 };
 
-bool IsCodeObjectUncompressed(const void* Image) {
+bool IsCodeObjectUncompressed(const void *Image) {
   return std::memcmp(Image,
-                     reinterpret_cast<const void*>(symbols::kOffloadBundleUncompressedMagicStr),
-                     sizeof(symbols::kOffloadBundleUncompressedMagicStr) - 1) == 0;
+                  reinterpret_cast<const void *>(
+                  symbols::kOffloadBundleUncompressedMagicStr),
+                  sizeof(symbols::kOffloadBundleUncompressedMagicStr) - 1) == 0;         
 }
 
-bool IsCodeObjectCompressed(const void* Image) {
+bool IsCodeObjectCompressed(const void *Image) {
   return std::memcmp(Image,
-                     reinterpret_cast<const void*>(symbols::kOffloadBundleCompressedMagicStr),
-                     sizeof(symbols::kOffloadBundleCompressedMagicStr) - 1) == 0;
+									reinterpret_cast<const void *>(
+									symbols::kOffloadBundleCompressedMagicStr),
+									sizeof(symbols::kOffloadBundleCompressedMagicStr) - 1) == 0;
 }
 
-uint64_t CalculateFatBinarySize(const void* Image, bool& IsCompressed){
-	const char* HeaderPtr = static_cast<const char*>(Image);
-	if(IsCodeObjectCompressed(Image)){
-		IsCompressed = true;
-		/// Skip the magic
-		HeaderPtr += 4;
-		uint16_t Version = *reinterpret_cast<const uint16_t*>(HeaderPtr);
-		/// Version num consumed and compression method
-		HeaderPtr += 4;
-		if(Version == 2){
-			uint32_t TotalSize = *reinterpret_cast<const uint32_t*>(HeaderPtr);
-			return TotalSize;
-		}
-		else if(Version == 3)	
-			return *reinterpret_cast<const uint64_t*>(HeaderPtr);
-		else
-			return 0;
-	}
-	/// TODO: Add FatBin offsets here for reference and above
-	else if (IsCodeObjectUncompressed(Image)) {
+uint64_t CalculateFatBinarySize(const void *Image, bool &IsCompressed) {
+  const char *HeaderPtr = static_cast<const char *>(Image);
+  if (IsCodeObjectCompressed(Image)) {
+    IsCompressed = true;
+    /// Skip the magic
+    HeaderPtr += 4;
+    uint16_t Version = *reinterpret_cast<const uint16_t *>(HeaderPtr);
+    /// Version num consumed and compression method
+    HeaderPtr += 4;
+    if (Version == 2) {
+      uint32_t TotalSize = *reinterpret_cast<const uint32_t *>(HeaderPtr);
+      return TotalSize;
+    } else if (Version == 3)
+      return *reinterpret_cast<const uint64_t *>(HeaderPtr);
+    else
+      return 0;
+  }
+  /// TODO: Add FatBin offsets here for reference and above
+  else if (IsCodeObjectUncompressed(Image)) {
     // 1. Skip Magic String (24 bytes)
-    HeaderPtr += 24; 
-    
+    HeaderPtr += 24;
+
     // 2. Read Number of Entries
-    uint64_t NumOfEntries = *reinterpret_cast<const uint64_t*>(HeaderPtr);
-    if (NumOfEntries == 0) return 32; // Magic(24) + Count(8)
+    uint64_t NumOfEntries = *reinterpret_cast<const uint64_t *>(HeaderPtr);
+    if (NumOfEntries == 0)
+      return 32; // Magic(24) + Count(8)
     HeaderPtr += 8;
 
     // We track the furthest byte reached in the file to determine TotalSize
@@ -107,26 +109,94 @@ uint64_t CalculateFatBinarySize(const void* Image, bool& IsCompressed){
 
     // 3. Walk the Metadata Table
     for (uint64_t i = 0; i < NumOfEntries; ++i) {
-        // Read fields exactly as laid out in the "Bundled Code Object Layout"
-        uint64_t ObjOffset = *reinterpret_cast<const uint64_t*>(HeaderPtr);
-        uint64_t ObjSize   = *reinterpret_cast<const uint64_t*>(HeaderPtr + 8);
-        uint64_t IDLength  = *reinterpret_cast<const uint64_t*>(HeaderPtr + 16);
+      // Read fields exactly as laid out in the "Bundled Code Object Layout"
+      uint64_t ObjOffset = *reinterpret_cast<const uint64_t *>(HeaderPtr);
+      uint64_t ObjSize = *reinterpret_cast<const uint64_t *>(HeaderPtr + 8);
+      uint64_t IDLength = *reinterpret_cast<const uint64_t *>(HeaderPtr + 16);
 
-        // Track the end of the actual binary data blobs
-        uint64_t EndOfCurrentBlob = ObjOffset + ObjSize;
-        if (EndOfCurrentBlob > FileTail) {
-            FileTail = EndOfCurrentBlob;
-        }
-        // Move HeaderPtr to the start of the next entry:
-        // Offset(8) + Size(8) + IDLength(8) + The ID String itself
-        HeaderPtr += (24 + IDLength);
+      // Track the end of the actual binary data blobs
+      uint64_t EndOfCurrentBlob = ObjOffset + ObjSize;
+      if (EndOfCurrentBlob > FileTail) 
+        FileTail = EndOfCurrentBlob;
+    
+      // Move HeaderPtr to the start of the next entry:
+      // Offset(8) + Size(8) + IDLength(8) + The ID String itself
+      HeaderPtr += (24 + IDLength);
     }
     // The total size is the end of the last code object found
     return FileTail;
-	}	
-	// Was not expecting an ELF here
-	return 0;
+  }
+  // Was not expecting an ELF here
+  return 0;
 }
+
+unsigned GetMach(const AMDGCNObjectFile &Obj) {
+  // e_flags contains the machine ID in the bits defined by EF_AMDGPU_MACH
+  return Obj.getPlatformFlags() & llvm::ELF::EF_AMDGPU_MACH;
+}
+
+/// Helper to count how many features are explicitly defined in the Target ID
+int GetSpecificityScore(const std::string& TargetID, bool IsGeneric) {
+    int score = 0;
+    /// Base architecture match is the baseline
+    if (!TargetID.empty()) score = 1;
+
+		/// Give high enough score to make sure non-generic ISA always gets picked
+    if(!IsGeneric) score += 10;
+
+    /// Each feature (+ or -) increases the specificity/score
+    for (char c : TargetID) {
+        if (c == '+' || c == '-') score++;
+    }
+    return score;
+}
+
+hsa_isa_t FindMostCompatibleISA(hsa_isa_t Candidate, bool IsCandidateGeneric, hsa_isa_t CurrentBest, bool IsCurrentBestGeneric) {
+
+		auto CandidateStrOrErr = hsa::isaGetName(Candidate);
+		if(!CandidateStrOrErr) return CurrentBest;
+		
+		auto BestStrOrErr = hsa::isaGetName(CurrentBest);
+		if(!BestStrOrErr) return Candidate;
+
+    std::string CandidateStr = std::move(*CandidateStrOrErr);
+    std::string BestStr = std::move(*BestStrOrErr);
+
+    /// Get the specificity scores
+    int CandidateScore = GetSpecificityScore(CandidateStr, IsCandidateGeneric);
+    int BestScore = GetSpecificityScore(BestStr, IsCurrentBestGeneric);
+
+    /// HIP prefers the higher specificity score (more features)
+    /// Example: "gfx908:sramecc+:xnack-" (Score 13) wins over "gfx908" (Score 11)
+    if (CandidateScore > BestScore) 
+        return Candidate;
+    
+    return CurrentBest;
+}
+
+/// Finds the ".llvmbc" section of the host storage ELF
+/// \param StorageELF the \c luthier::object::AMDGCNObjectFile reference
+/// \return an \c llvm::StringRef to the contents of the ".llvmbc" section
+/// if found, or an \c llvm::Error if the bitcode was not found
+llvm::Expected<llvm::StringRef>
+getBitcodeBufferOfAMDGCNObjectFile(luthier::object::AMDGCNObjectFile &StorageELF) {
+  // Find the ".llvmbc" section of the ELF
+  for (const llvm::object::SectionRef &Section : StorageELF.sections()) {
+    auto SectionName = Section.getName();
+    LUTHIER_RETURN_ON_ERROR(SectionName.takeError());
+    
+    if (*SectionName == BCSectionName) {
+      auto SectionContents = Section.getContents();
+      LUTHIER_RETURN_ON_ERROR(SectionContents.takeError());
+      
+      return *SectionContents;
+    }
+  }
+  
+  return llvm::make_error<GenericLuthierError>(
+      "Failed to find the bitcode section (.llvmbc) inside the AMDGCN storage ELF.");
+}
+
 } // namespace
 
 namespace luthier {
@@ -428,102 +498,179 @@ bool ToolExecutableLoader::isKernelInstrumented(
              ->second.contains(Preset);
 }
 
+llvm::Error
+ToolExecutableLoader::RegisterFatBinary(const void *RawFatBinWrapper) {
+  const HipFatBinary *FatBinWrapper =
+      static_cast<HipFatBinary *>(RawFatBinWrapper);
 
+  LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
+      FatBinWrapper->version == 1,
+      llvm::formatv("Cannot Register fat binary. Invalid version: {0}",
+                    FatBinWrapper->version)));
 
-llvm::Error ToolExecutableLoader::RegisterFatBinary(const void* RawFatBinWrapper){
-	const HipFatBinary* FatBinWrapper = static_cast<HipFatBinary*>(RawFatBinWrapper);
-	LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
-		FatBinWrapper->version == 1,
-		llvm::formatv("Cannot Register fat binary. Invalid version: {0}",
-									FatBinWrapper->version)));
-	LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
-		FatBinWrapper->magic == HipFatMAGIC2,
-		llvm::formatv("Fat binary wrapper has {0} magic number instead of {1}",
-									FatBinWrapper->magic, HipFatMAGIC2)));
-	void* Binary = FatBinWrapper->binary;
-	bool IsCompressed = false;
-	uint64_t BinarySize = CalculateBinarySize(Binary, IsCompressed);
-	LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
-		BinarySize == 0,
-		llvm::formatv("Fat binary is malformed or incorrect")));
-	if(IsCompressed && BinarySize == 32) return llvm::Error::success(); // No binaries to be processed???
+  LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
+      FatBinWrapper->magic == HipFatMAGIC2,
+      llvm::formatv("Fat binary wrapper has {0} magic number instead of {1}",
+                    FatBinWrapper->magic, HipFatMAGIC2)));
 
-	const char* FatBinData = static_cast<const char*>(Binary);
-	std::unique_ptr<llvm::MemoryBuffer> RawBuffer = llvm::MemoryBuffer::getMemBuffer(
-			llvm::StringRef(FatBinData, BinarySize),
-			"Fat Binary Buffer",
-			/*RequiresNullTerminator=*/false
-	);
+  void *Binary = FatBinWrapper->binary;
+  bool IsCompressed = false;
 
-	std::unique_ptr<llvm::MemoryBuffer> FinalDecompressedBuffer;
-	if (IsCompressed) {
-			auto DecompressedOrErr = llvm::object::CompressedOffloadBundle::decompress(*RawBuffer);
-			/// TODO: Update this
-			if (!DecompressedOrErr) {		
-					return DecompressedOrErr.takeError();
-			}
-			
-			// Ownership of the newly allocated, decompressed heap memory is moved here
-			FinalDecompressedBuffer = std::move(*DecompressedOrErr);
-	} else {
-			// If it's not compressed, just pass the raw wrapper right through.
-			// Zero allocations, zero copies.
-			FinalDecompressedBuffer = std::move(RawBuffer);
+  uint64_t BinarySize = CalculateFatBinarySize(Binary, IsCompressed);
+
+  LUTHIER_RETURN_ON_ERROR(LUTHIER_GENERIC_ERROR_CHECK(
+      BinarySize != 0, llvm::formatv("Fat binary is malformed or incorrect")));
+
+  if (IsCompressed && BinarySize == 32)
+    return llvm::Error::success(); // No binaries to be processed???
+
+  const char *FatBinData = static_cast<const char *>(Binary);
+  std::unique_ptr<llvm::MemoryBuffer> RawBuffer =
+      llvm::MemoryBuffer::getMemBuffer(llvm::StringRef(FatBinData, BinarySize),
+                                       "Fat Binary Buffer",
+                                       /*RequiresNullTerminator=*/false);
+
+  std::unique_ptr<llvm::MemoryBuffer> FinalDecompressedBuffer;
+
+  if (IsCompressed) {
+    auto DecompressedOrErr =
+        llvm::object::CompressedOffloadBundle::decompress(*RawBuffer);
+
+  	LUTHIER_RETURN_ON_ERROR(DecompressedOrErr.takeError());
+    // Ownership of the newly allocated, decompressed heap memory is moved here
+    FinalDecompressedBuffer = std::move(*DecompressedOrErr);
+  } else {
+    // If it's not compressed, just pass the raw wrapper right through.
+    // Zero allocations, zero copies.
+    FinalDecompressedBuffer = std::move(RawBuffer);
+  }
+
+	const char *BaseDataPtr = FinalDecompressedBuffer->getBufferStart();
+
+  llvm::MemoryBufferRef FatBinRef = FinalDecompressedBuffer->getMemBufferRef();
+
+  auto FatBinBundleOrErr =
+      llvm::object::OffloadBundleFatBin::create(FatBinRef, 0, "hip-fat-binary");
+
+  LUTHIER_RETURN_ON_ERROR(FatBinBundleOrErr.takeError());
+
+  std::unique_ptr<llvm::object::OffloadBundleFatBin> FatBinBundle =
+      std::move(*FatBinBundleOrErr);
+
+  llvm::SmallVector<llvm::object::OffloadBundleEntry> FatBinEntries =
+      FatBinBundle->GetEntries();
+
+  llvm::SmallVector<hsa_agent_t, 4> AvailableAgents;
+  llvm::DenseMap<hsa_agent_t, llvm::SmallVector<hsa_isa_t, 4>> AgentSupportedISA;
+	/// Also store if MACH of the code object is generic
+  llvm::DenseMap<hsa_agent_t,
+                 std::tuple<llvm::object::OffloadBundleEntry, hsa_isa_t, bool, std::unique_ptr<luthier::object::AMDGCNObjectFile>>> AgentCompatibleCO;
+
+  auto Err =
+      luthier::hsa::getGpuAgents(CoreApiSnapshot.getTable(), AvailableAgents);
+  if (Err != llvm::Error::success())
+    return Err;
+
+  for (auto Agent : AvailableAgents) {
+    auto Err = luthier::hsa::agentGetSupportedISAs(
+        CoreApiSnapshot.getTable(), Agent, AgentSupportedISA[Agent]);
+    if (Err != llvm::Error::success())
+      return Err;
+  }
+
+  for (llvm::object::OffloadBundleEntry BundleEntry : FatBinEntries) {
+    void *COData = const_cast<char*>(BaseDataPtr + BundleEntry.Offset);
+    size_t COSize = BundleEntry.Size;
+
+    llvm::MemoryBufferRef COBufferRef(llvm::StringRef(COData, COSize), "CO object");
+
+    auto COErr =
+        luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
+  	LUTHIER_RETURN_ON_ERROR(COErr.takeError());
+
+    std::unique_ptr<luthier::object::AMDGCNObjectFile> CO = std::move(*COErr);
+
+    auto TargetTupleOrErr = luthier::object::getObjectFileTargetTuple(*CO);
+		LUTHIER_RETURN_ON_ERROR(TargetTupleOrErr.takeError());
+
+    std::tuple<llvm::Triple, llvm::StringRef, llvm::SubtargetFeatures>
+        TargetTuple = std::move(*TargetTupleOrErr);
+
+    // Pluck individual items out using their index (0, 1, 2)
+    llvm::Triple Triple = std::get<0>(TargetTuple);
+    llvm::StringRef CpuName = std::get<1>(TargetTuple);
+    llvm::SubtargetFeatures Features = std::get<2>(TargetTuple);
+
+    auto ISAOrErr = luthier::hsa::isaFromLLVM(CoreApiSnapshot.getTable(),
+                                              Triple, CpuName, Features);
+		LUTHIER_RETURN_ON_ERROR(ISAOrErr.takeError());
+
+    hsa_isa_t CodeObjectISA = *ISAOrErr;
+
+    for (auto Agent : AvailableAgents) {
+      /// Loop through AGENT ISA and compare handles
+      /// hsa_isa_t only holds an integer handle so copies are not detremental
+      for (hsa_isa_t AgentISA : AgentSupportedISA[Agent]) {
+				if (AgentISA.handle != CodeObjectISA.handle) continue;
+				/// If try_emplace fails this means an entry for this agent exists 
+				/// and we need to determine the best CO
+				bool IsGeneric = object::isGenericAMDGPUMach(GetMach(*CO));
+				// auto [it, Inserted] = AgentCompatibleCO.try_emplace(Agent, BundleEntry, AgentISA, IsGeneric);
+				auto it = AgentCompatibleCO.find(Agent);
+				if (it == AgentCompatibleCO.end()) {
+          auto NewCOErr = luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
+          LUTHIER_RETURN_ON_ERROR(NewCOErr.takeError());
+          AgentCompatibleCO[Agent] = { BundleEntry, AgentISA, IsGeneric, std::move(*NewCOErr) };
+        }
+				else {
+					hsa_isa_t ExistingISA = std::get<1>(it->second);
+          bool ExistingIsGeneric = std::get<2>(it->second);
+          hsa_isa_t MostCompatible = FindMostCompatibleISA(AgentISA, IsGeneric, ExistingISA, ExistingIsGeneric);
+
+          if (MostCompatible == AgentISA) {
+            auto NewCOErr = luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
+            LUTHIER_RETURN_ON_ERROR(NewCOErr.takeError());
+            it->second = { BundleEntry, AgentISA, IsGeneric, std::move(*NewCOErr) };
+          }
+				}
+				/// If we found a match no use to loop over the rest of the ISAs
+				break;
+      }
+    }
+  }
+	for(auto& [Agent, COTuple] : AgentCompatibleCO){
+		auto& [COEntry, ISA, IsGeneric, AMDObjectFile] = COTuple;
+
+		void *COData = const_cast<char*>(BaseDataPtr + COEntry.Offset);
+    size_t COSize = COEntry.Size;
+
+		auto CoreApiTable = CoreApiSnapshot.getTable();
+
+		// Create the executable
+		auto Executable = hsa::executableCreate(CoreApiTable);
+		LUTHIER_RETURN_ON_ERROR(Executable.takeError());
+
+		llvm::StringRef CORef{ COData, COSize };        
+		auto Reader =
+				hsa::codeObjectReaderCreateFromMemory(CoreApiTable, CORef);
+		LUTHIER_RETURN_ON_ERROR(Reader.takeError());
+		auto LCO = hsa::executableLoadAgentCodeObject(CoreApiTable, *Executable,
+																									*Reader, Agent);
+		LUTHIER_RETURN_ON_ERROR(LCO.takeError());
+		// Freeze the executable
+		LUTHIER_RETURN_ON_ERROR(hsa::executableFreeze(CoreApiTable, *Executable));
+
+		AgentLoadedExecutables[Agent] = *Executable;
+
+		/// Track Code Object bitcode per agent
+		auto BitcodeOrErr = getBitcodeBufferOfAMDGCNObjectFile(*AMDObjectFile);
+    LUTHIER_RETURN_ON_ERROR(BitcodeOrErr.takeError());
+    AgentExecutableBitcode[Agent] = *BitcodeOrErr;
 	}
 
-	llvm::MemoryBufferRef FatBinRef = FinalDecompressedBuffer->getMemBufferRef();
-	auto FatBinBundleOrErr = llvm::object::OffloadBundleFatBin::create(FatBinRef, 0, "hip-fat-binary");
-	if(!FatBinBundleOrErr)
-		return FatBinBundleOrErr.takeError();
-	std::unique_ptr<llvm::object::OffloadBundleFatBin> FatBinBundle = std::move(*FatBinBundleOrErr); 
-	llvm::SmallVector<llvm::object::OffloadBundleEntry> FatBinEntries = FatBinBundle->GetEntries();
-	llvm::SmallVector<hsa_agent_t, 4> AvailableAgents;
-	/// FIXME: Change to hsa_agent_t-> vector<std::string(ISA name)
-	llvm::DenseMap<hsa_agent_t, llvm::SmallVector<hsa_isa_t, 4>> AgentSupportedISA;
-	/// Probably move this in TEL members
-	llvm::DenseMap<hsa_agent_t, llvm::SmallVector<hsa_executable_t, 4>> AgentLoadedExecutables;
-	auto Err = luthier::hsa::getGpuAgents(CoreApiSnapshot.getTable(), AvailableAgents);
-	if(Err != llvm::Error::success())
-		return Err;
-	
-	for(auto Agent : AvailableAgents){
-		auto Err = luthier::hsa::agentGetSupportedISAs(CoreApiSnapshot.getTable(), Agent, AgentSupportedISA[Agent]);
-		if(Err != llvm::Error::success())
-			return Err;
-	}
-	for(llvm::object::OffloadBundleEntry BundleEntry : FatBinEntries){
-		void* COData = FatBinData + BundleEntry.Offset;
-		size_t COSize = BundleEntry.Size;
-		std::unique_ptr<llvm::MemoryBuffer> COBufferRaw = llvm::MemoryBuffer::getMemBuffer(
-			llvm::StringRef(COData, COSize),
-			"CO object",
-			/*RequiresNullTerminator=*/false);
-		llvm::MemoryBufferRef COBufferRef = COBufferRaw->getMemBufferRef();
-		auto COErr = luthier::object::AMDGCNObjectFile::createAMDGCNObjectFile(COBufferRef);
-		if(!COErr){
-			return COErr.takeError();
-		}
-		std::unique_ptr<luthier::object::AMDGCNObjectFile> CO = std::move(*COErr);
-		auto TargetTupleOrErr = luthier::object::getObjectFileTargetTuple(*CO);
-		if(!TargetTupleOrErr){
-			TargetTupleOrErr.takeError();
-		}
-		std::tuple<llvm::Triple, llvm::StringRef, llvm::SubtargetFeatures> TargetTuple = std::move(*TupleOrErr);
+	ManagedFatBinBuffers.push_back(std::move(FinalDecompressedBuffer));
 
-		// Pluck individual items out using their index (0, 1, 2)
-		llvm::Triple            Triple   = std::get<0>(TargetTuple);
-		llvm::StringRef         CpuName  = std::get<1>(TargetTuple);
-		llvm::SubtargetFeatures Features = std::get<2>(TargetTuple);
-
-		auto ISAOrErr = luthier::hsa::isaFromLLVM(CoreApiSnapshot.getTable(), Triple, CpuName, Features);
-		if(!ISAOrErr){
-			ISAOrErr.takeError();
-		}
-		hsa_isa_t CodeObjectISA = std::move(*ISAOrErr);
-		for(auto Agent : AvailableAgents){
-			// Loop through AGENT ISA and compare handles
-		}
-	}
+	return llvm::Error::success();
 }
 
 ToolExecutableLoader::~ToolExecutableLoader() {

--- a/src/lib/Object/ObjectFileUtils.cpp
+++ b/src/lib/Object/ObjectFileUtils.cpp
@@ -21,6 +21,68 @@
 #include "luthier/Common/ErrorCheck.h"
 #include "luthier/Common/GenericLuthierError.h"
 #include <llvm/TargetParser/SubtargetFeature.h>
+#include <llvm/Object/ELF.h>
+
+namespace {
+
+enum class FeatureState {
+  Off,
+  On,
+  Any
+};
+
+bool GetSramEccAndXnackState(const llvm::object::ObjectFile *ObjFile, 
+                             FeatureState &SramEccEnabled, 
+                             FeatureState &XnackEnabled) {
+
+  SramEccEnabled = FeatureState::Off;
+  XnackEnabled = FeatureState::Off;
+
+  if (!ObjFile) return false;
+
+  if (auto *ElfObj = llvm::dyn_cast<llvm::object::ELFObjectFileBase>(ObjFile)) {
+    uint32_t EFlags = ElfObj->getPlatformFlags();
+
+    // Isolate and compare XNACK
+    uint32_t XnackBits = EFlags & llvm::ELF::EF_AMDGPU_FEATURE_XNACK_ANY_V4;
+    if (XnackBits == llvm::ELF::EF_AMDGPU_FEATURE_XNACK_ANY_V4) {
+        XnackEnabled = FeatureState::Any;
+    } else if (XnackBits == llvm::ELF::EF_AMDGPU_FEATURE_XNACK_ON_V4) {
+        XnackEnabled = FeatureState::On;
+    } else if (XnackBits == llvm::ELF::EF_AMDGPU_FEATURE_XNACK_OFF_V4) {
+        XnackEnabled = FeatureState::Off;
+    }
+
+    // Isolate and compare SRAMECC
+    uint32_t SramEccBits = EFlags & llvm::ELF::EF_AMDGPU_FEATURE_SRAMECC_ANY_V4;
+    if (SramEccBits == llvm::ELF::EF_AMDGPU_FEATURE_SRAMECC_ANY_V4) {
+        SramEccEnabled = FeatureState::Any;
+    } else if (SramEccBits == llvm::ELF::EF_AMDGPU_FEATURE_SRAMECC_ON_V4) {
+        SramEccEnabled = FeatureState::On;
+    } else if (SramEccBits == llvm::ELF::EF_AMDGPU_FEATURE_SRAMECC_OFF_V4) {
+        SramEccEnabled = FeatureState::Off;
+    }
+    return true;  
+  }
+  return false;
+}
+
+void AddFeaturesIfNeeded(llvm::SubtargetFeatures& Features, const llvm::object::ObjectFile &ObjFile) {
+  FeatureState Xnack;
+  FeatureState SramEcc;
+  if (GetSramEccAndXnackState(&ObjFile, SramEcc, Xnack)) {
+    if (SramEcc != FeatureState::Any) {
+      bool SramEccEnabled = (SramEcc == FeatureState::On);
+      Features.AddFeature("sramecc", SramEccEnabled);
+    }
+    if (Xnack != FeatureState::Any) {
+      bool XnackEnabled = (Xnack == FeatureState::On);
+      Features.AddFeature("xnack", XnackEnabled);
+    }
+  }
+}
+
+} // namespace
 
 namespace luthier::object {
 
@@ -39,7 +101,7 @@ getObjectFileTarget(const llvm::object::ObjectFile &ObjFile) {
   llvm::Expected<llvm::SubtargetFeatures> SubTargetFeaturesOrErr =
       ObjFile.getFeatures();
   LUTHIER_RETURN_ON_ERROR(SubTargetFeaturesOrErr.takeError());
-
+  AddFeaturesIfNeeded(*SubTargetFeaturesOrErr, ObjFile);
   std::string Out =
       TT.str() + "--" +
       (CpuNameIfAvailable.has_value() ? std::string(*CpuNameIfAvailable)
@@ -59,6 +121,7 @@ getObjectFileTargetTuple(const llvm::object::ObjectFile &Obj) {
       CPU.has_value(), "Failed to get the CPU name of the object file."));
   llvm::SubtargetFeatures Features;
   LUTHIER_RETURN_ON_ERROR(Obj.getFeatures().moveInto(Features));
+  AddFeaturesIfNeeded(Features, Obj);
   return std::make_tuple(TT, *CPU, Features);
 }
 


### PR DESCRIPTION
Note: This is in dradft phase as not everything is implemented yet, only the FatBinary parsing, also there are no tests yet

This PR fixes #78 and is a continuation of #75 in the effort of delegating hip functions to the ToolExecutableLoader.

This PR provides the ToolExecutableLoader with registration functions for Fat binaries and keeps track of LLVM bitcode, and will soon have query methods to get said bitcode as well as the frozen executables.

What's done:
FatBinary parsing: Replicated HIP's parsing logic using LLVM's offload utilities to handle both compressed and uncompressed bundles.

Agent matching: Implemented the selection loop to find, load, and freeze the most specific compatible code object for each available HSA agent.

Bitcode extraction: Added logic to loop through the ELF sections, extract the .llvmbc bitcode buffer, and track it per agent in AgentExecutableBitcode.

Lifetime management: Moved the decompressed buffers into ManagedFatBinBuffers at the end of the pipeline so all zero-copy string views stay perfectly valid.

Todo before merging:
Implement the public query methods to fetch the cached bitcode and frozen executables.

Add handle-to-name utility mapping for tracking host handles of hooks and global variables.

Provide APIs to query where global variables are loaded on a target HSA agent.

Write tests (none yet as this is a draft).